### PR TITLE
[Feat] 도시 검색 화면 구현

### DIFF
--- a/LZForecast/LZForecast.xcodeproj/project.pbxproj
+++ b/LZForecast/LZForecast.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		CEB45ACF2C44579A00327314 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = CEB45ACE2C44579A00327314 /* Kingfisher */; };
 		CEB45AD12C446AC900327314 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD02C446AC900327314 /* Weekday.swift */; };
 		CEB45AD52C446DF100327314 /* CityList.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB45AD42C446DF100327314 /* CityList.json */; };
+		CEB45AD72C446E7900327314 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD62C446E7900327314 /* FileManager.swift */; };
 		CED1E1A62C3E79A5004BFBE1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */; };
 		CED1E1A82C3E79A5004BFBE1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */; };
 		CED1E1AA2C3E79A5004BFBE1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A92C3E79A5004BFBE1 /* ViewController.swift */; };
@@ -70,6 +71,7 @@
 		CEB45AA62C44247B00327314 /* FiveDayForecastTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveDayForecastTableViewCell.swift; sourceTree = "<group>"; };
 		CEB45AD02C446AC900327314 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		CEB45AD42C446DF100327314 /* CityList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CityList.json; sourceTree = "<group>"; };
+		CEB45AD62C446E7900327314 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		CED1E1A22C3E79A5004BFBE1 /* LZForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LZForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				CEB45A892C42F4C300327314 /* WeatherAPIManager.swift */,
+				CEB45AD62C446E7900327314 /* FileManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -424,6 +427,7 @@
 				CEB45AA12C43E10F00327314 /* CityInfo.swift in Sources */,
 				CED1E1A62C3E79A5004BFBE1 /* AppDelegate.swift in Sources */,
 				CED1E1E62C3FED29004BFBE1 /* Reusable.swift in Sources */,
+				CEB45AD72C446E7900327314 /* FileManager.swift in Sources */,
 				CEB45AA32C44136C00327314 /* ThreeHourForecast.swift in Sources */,
 				CEB45A8A2C42F4C300327314 /* WeatherAPIManager.swift in Sources */,
 				CED1E1F12C3FFD9D004BFBE1 /* BaseCollectionViewCell.swift in Sources */,

--- a/LZForecast/LZForecast.xcodeproj/project.pbxproj
+++ b/LZForecast/LZForecast.xcodeproj/project.pbxproj
@@ -28,6 +28,11 @@
 		CEB45AD12C446AC900327314 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD02C446AC900327314 /* Weekday.swift */; };
 		CEB45AD52C446DF100327314 /* CityList.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB45AD42C446DF100327314 /* CityList.json */; };
 		CEB45AD72C446E7900327314 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD62C446E7900327314 /* FileManager.swift */; };
+		CEB45AD92C44709E00327314 /* SearchCityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD82C44709E00327314 /* SearchCityViewController.swift */; };
+		CEB45ADB2C4470B500327314 /* SearchCityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45ADA2C4470B500327314 /* SearchCityView.swift */; };
+		CEB45ADD2C4473F500327314 /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45ADC2C4473F500327314 /* City.swift */; };
+		CEB45AE02C44742100327314 /* SearchCityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45ADF2C44742100327314 /* SearchCityViewModel.swift */; };
+		CEB45AE22C4474B300327314 /* SearchCityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AE12C4474B300327314 /* SearchCityCell.swift */; };
 		CED1E1A62C3E79A5004BFBE1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */; };
 		CED1E1A82C3E79A5004BFBE1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */; };
 		CED1E1AA2C3E79A5004BFBE1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A92C3E79A5004BFBE1 /* ViewController.swift */; };
@@ -72,6 +77,11 @@
 		CEB45AD02C446AC900327314 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		CEB45AD42C446DF100327314 /* CityList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CityList.json; sourceTree = "<group>"; };
 		CEB45AD62C446E7900327314 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
+		CEB45AD82C44709E00327314 /* SearchCityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCityViewController.swift; sourceTree = "<group>"; };
+		CEB45ADA2C4470B500327314 /* SearchCityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCityView.swift; sourceTree = "<group>"; };
+		CEB45ADC2C4473F500327314 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
+		CEB45ADF2C44742100327314 /* SearchCityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCityViewModel.swift; sourceTree = "<group>"; };
+		CEB45AE12C4474B300327314 /* SearchCityCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCityCell.swift; sourceTree = "<group>"; };
 		CED1E1A22C3E79A5004BFBE1 /* LZForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LZForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +158,7 @@
 				CEB45AA22C44136C00327314 /* ThreeHourForecast.swift */,
 				CEB45AA42C44139900327314 /* FiveDayForecast.swift */,
 				CEB45AD02C446AC900327314 /* Weekday.swift */,
+				CEB45ADC2C4473F500327314 /* City.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -171,6 +182,10 @@
 		CEB45AD22C446CCE00327314 /* SearchCity */ = {
 			isa = PBXGroup;
 			children = (
+				CEB45ADE2C44741800327314 /* ViewModel */,
+				CEB45AD82C44709E00327314 /* SearchCityViewController.swift */,
+				CEB45ADA2C4470B500327314 /* SearchCityView.swift */,
+				CEB45AE12C4474B300327314 /* SearchCityCell.swift */,
 			);
 			path = SearchCity;
 			sourceTree = "<group>";
@@ -181,6 +196,14 @@
 				CEB45AD42C446DF100327314 /* CityList.json */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		CEB45ADE2C44741800327314 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CEB45ADF2C44742100327314 /* SearchCityViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		CED1E1992C3E79A5004BFBE1 = {
@@ -414,6 +437,7 @@
 				CED1E1EC2C3FF54D004BFBE1 /* UICollectionView+Extension.swift in Sources */,
 				CED1E1BD2C3E7FB4004BFBE1 /* BaseViewController.swift in Sources */,
 				CED1E1E32C3FEC5B004BFBE1 /* MainView.swift in Sources */,
+				CEB45ADD2C4473F500327314 /* City.swift in Sources */,
 				CED1E1E82C3FEE6D004BFBE1 /* CityInfoCell.swift in Sources */,
 				CEB45A802C42AE0000327314 /* MapCell.swift in Sources */,
 				CED1E1E12C3FEC57004BFBE1 /* MainViewController.swift in Sources */,
@@ -426,6 +450,7 @@
 				CED1E1EF2C3FF66D004BFBE1 /* ScreenSize.swift in Sources */,
 				CEB45AA12C43E10F00327314 /* CityInfo.swift in Sources */,
 				CED1E1A62C3E79A5004BFBE1 /* AppDelegate.swift in Sources */,
+				CEB45AE02C44742100327314 /* SearchCityViewModel.swift in Sources */,
 				CED1E1E62C3FED29004BFBE1 /* Reusable.swift in Sources */,
 				CEB45AD72C446E7900327314 /* FileManager.swift in Sources */,
 				CEB45AA32C44136C00327314 /* ThreeHourForecast.swift in Sources */,
@@ -437,13 +462,16 @@
 				CEB45A9A2C43C46000327314 /* WeatherCurrentResponse.swift in Sources */,
 				CEB45A902C42FE8400327314 /* APIKey.swift in Sources */,
 				CED1E1CE2C3F49C6004BFBE1 /* UIButton+Extension.swift in Sources */,
+				CEB45ADB2C4470B500327314 /* SearchCityView.swift in Sources */,
 				CED1E1C62C3E86B6004BFBE1 /* Observable.swift in Sources */,
 				CED1E1BB2C3E7F41004BFBE1 /* BaseView.swift in Sources */,
 				CEB45A982C43C43800327314 /* RequestDataType.swift in Sources */,
 				CEB45AA52C44139900327314 /* FiveDayForecast.swift in Sources */,
+				CEB45AD92C44709E00327314 /* SearchCityViewController.swift in Sources */,
 				CED1E1DE2C3FC190004BFBE1 /* BaseTableViewCell.swift in Sources */,
 				CEB45A9C2C43C8FE00327314 /* WeatherForecastResponse.swift in Sources */,
 				CED1E1CB2C3F46CF004BFBE1 /* CompositionalViewController.swift in Sources */,
+				CEB45AE22C4474B300327314 /* SearchCityCell.swift in Sources */,
 				CEB45A9F2C43DE1700327314 /* MainViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LZForecast/LZForecast.xcodeproj/project.pbxproj
+++ b/LZForecast/LZForecast.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		CEB45AA72C44247B00327314 /* FiveDayForecastTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AA62C44247B00327314 /* FiveDayForecastTableViewCell.swift */; };
 		CEB45ACF2C44579A00327314 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = CEB45ACE2C44579A00327314 /* Kingfisher */; };
 		CEB45AD12C446AC900327314 /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB45AD02C446AC900327314 /* Weekday.swift */; };
+		CEB45AD52C446DF100327314 /* CityList.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB45AD42C446DF100327314 /* CityList.json */; };
 		CED1E1A62C3E79A5004BFBE1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */; };
 		CED1E1A82C3E79A5004BFBE1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */; };
 		CED1E1AA2C3E79A5004BFBE1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1A92C3E79A5004BFBE1 /* ViewController.swift */; };
@@ -68,6 +69,7 @@
 		CEB45AA42C44139900327314 /* FiveDayForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveDayForecast.swift; sourceTree = "<group>"; };
 		CEB45AA62C44247B00327314 /* FiveDayForecastTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveDayForecastTableViewCell.swift; sourceTree = "<group>"; };
 		CEB45AD02C446AC900327314 /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
+		CEB45AD42C446DF100327314 /* CityList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CityList.json; sourceTree = "<group>"; };
 		CED1E1A22C3E79A5004BFBE1 /* LZForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LZForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED1E1A52C3E79A5004BFBE1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CED1E1A72C3E79A5004BFBE1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -163,6 +165,21 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		CEB45AD22C446CCE00327314 /* SearchCity */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SearchCity;
+			sourceTree = "<group>";
+		};
+		CEB45AD32C446DE600327314 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				CEB45AD42C446DF100327314 /* CityList.json */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
 		CED1E1992C3E79A5004BFBE1 = {
 			isa = PBXGroup;
 			children = (
@@ -218,6 +235,7 @@
 			children = (
 				CED1E1DF2C3FEC44004BFBE1 /* Compositional(Test) */,
 				CED1E1C72C3F46B3004BFBE1 /* Main */,
+				CEB45AD22C446CCE00327314 /* SearchCity */,
 				CED1E1A92C3E79A5004BFBE1 /* ViewController.swift */,
 			);
 			path = Views;
@@ -237,6 +255,7 @@
 				CEB45A8E2C42FE7E00327314 /* APIKeys */,
 				CEB45A942C43C3F600327314 /* Builders */,
 				CED1E1ED2C3FF664004BFBE1 /* Constants */,
+				CEB45AD32C446DE600327314 /* Data */,
 				CED1E1CC2C3F49BC004BFBE1 /* Extensions */,
 				CEB45A882C42F4A500327314 /* Managers */,
 				CED1E1C42C3E86AF004BFBE1 /* Observable */,
@@ -374,6 +393,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED1E1AF2C3E79A7004BFBE1 /* Assets.xcassets in Resources */,
+				CEB45AD52C446DF100327314 /* CityList.json in Resources */,
 				CED1E1B22C3E79A7004BFBE1 /* Base in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LZForecast/LZForecast/Utils/Data/CityList.json
+++ b/LZForecast/LZForecast/Utils/Data/CityList.json
@@ -1,0 +1,1771 @@
+[{
+        "id": 1832008,
+        "name": "Tokusan-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.699997,
+            "lat": 35.133331
+        }
+    },
+    {
+        "id": 1832015,
+        "name": "Heunghae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.352219,
+            "lat": 36.112499
+        }
+    },
+    {
+        "id": 1832157,
+        "name": "Reisui",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.737778,
+            "lat": 34.744171
+        }
+    },
+    {
+        "id": 1832215,
+        "name": "Yeonil",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.345001,
+            "lat": 35.994171
+        }
+    },
+    {
+        "id": 1832257,
+        "name": "Neietsu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.468216,
+            "lat": 37.184471
+        }
+    },
+    {
+        "id": 1832384,
+        "name": "Eisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.630829,
+            "lat": 36.821671
+        }
+    },
+    {
+        "id": 1832427,
+        "name": "Yongin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.20639,
+            "lat": 37.234169
+        }
+    },
+    {
+        "id": 1832501,
+        "name": "Yeonggwang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.509438,
+            "lat": 35.275002
+        }
+    },
+    {
+        "id": 1832566,
+        "name": "Yeongdong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.77639,
+            "lat": 36.174999
+        }
+    },
+    {
+        "id": 1832617,
+        "name": "Eisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.930832,
+            "lat": 35.967499
+        }
+    },
+    {
+        "id": 1832663,
+        "name": "Yeongam-guncheong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.699997,
+            "lat": 34.798328
+        }
+    },
+    {
+        "id": 1832697,
+        "name": "Yeoncheon-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.075768,
+            "lat": 38.09404
+        }
+    },
+    {
+        "id": 1832743,
+        "name": "Yeoju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.633888,
+            "lat": 37.29583
+        }
+    },
+    {
+        "id": 1832771,
+        "name": "Yesan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.84272,
+            "lat": 36.677559
+        }
+    },
+    {
+        "id": 1832798,
+        "name": "Yecheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.45694,
+            "lat": 36.65556
+        }
+    },
+    {
+        "id": 1832809,
+        "name": "Yangyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.621109,
+            "lat": 38.073891
+        }
+    },
+    {
+        "id": 1832828,
+        "name": "Yangsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.038605,
+            "lat": 35.338612
+        }
+    },
+    {
+        "id": 1832830,
+        "name": "Yangp'yŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.490562,
+            "lat": 37.489719
+        }
+    },
+    {
+        "id": 1832847,
+        "name": "Yangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.061691,
+            "lat": 37.833111
+        }
+    },
+    {
+        "id": 1832909,
+        "name": "Yanggu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.989441,
+            "lat": 38.105831
+        }
+    },
+    {
+        "id": 1832973,
+        "name": "Yach’on",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.815826,
+            "lat": 35.13028
+        }
+    },
+    {
+        "id": 1833105,
+        "name": "Wŏnju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.945282,
+            "lat": 37.351391
+        }
+    },
+    {
+        "id": 1833466,
+        "name": "Wanju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.147522,
+            "lat": 35.845089
+        }
+    },
+    {
+        "id": 1833514,
+        "name": "Waegwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.397324,
+            "lat": 35.991749
+        }
+    },
+    {
+        "id": 1833581,
+        "name": "Unsal-li",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.20472,
+            "lat": 38.054169
+        }
+    },
+    {
+        "id": 1833702,
+        "name": "Umulmok",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.316673,
+            "lat": 38.049999
+        }
+    },
+    {
+        "id": 1833742,
+        "name": "Ulsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.266663,
+            "lat": 35.566669
+        }
+    },
+    {
+        "id": 1833747,
+        "name": "Ulsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.316666,
+            "lat": 35.53722
+        }
+    },
+    {
+        "id": 1833763,
+        "name": "Ulchin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.399994,
+            "lat": 36.992939
+        }
+    },
+    {
+        "id": 1833788,
+        "name": "Uijeongbu-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.047401,
+            "lat": 37.741501
+        }
+    },
+    {
+        "id": 1834885,
+        "name": "Tangjin",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.629723,
+            "lat": 36.89444
+        }
+    },
+    {
+        "id": 1835096,
+        "name": "Taesal-li",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.454201,
+            "lat": 36.971401
+        }
+    },
+    {
+        "id": 1835224,
+        "name": "Daejeon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.416672,
+            "lat": 36.333328
+        }
+    },
+    {
+        "id": 1835235,
+        "name": "Daejeon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.419724,
+            "lat": 36.321388
+        }
+    },
+    {
+        "id": 1835327,
+        "name": "Daegu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.550003,
+            "lat": 35.799999
+        }
+    },
+    {
+        "id": 1835329,
+        "name": "Daegu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.59111,
+            "lat": 35.870281
+        }
+    },
+    {
+        "id": 1835447,
+        "name": "Boryeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.597717,
+            "lat": 36.349312
+        }
+    },
+    {
+        "id": 1835515,
+        "name": "T’aebaek",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.988907,
+            "lat": 37.1759
+        }
+    },
+    {
+        "id": 1835518,
+        "name": "Taian",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.297783,
+            "lat": 36.75639
+        }
+    },
+    {
+        "id": 1835553,
+        "name": "Suwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.008888,
+            "lat": 37.291111
+        }
+    },
+    {
+        "id": 1835648,
+        "name": "Suncheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.489471,
+            "lat": 34.948078
+        }
+    },
+    {
+        "id": 1835650,
+        "name": "Sunchang-chodeunghakgyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.142776,
+            "lat": 35.373611
+        }
+    },
+    {
+        "id": 1835841,
+        "name": "Republic of Korea",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.5,
+            "lat": 37.0
+        }
+    },
+    {
+        "id": 1835847,
+        "name": "Seoul",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.583328
+        }
+    },
+    {
+        "id": 1835848,
+        "name": "Seoul",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.977829,
+            "lat": 37.56826
+        }
+    },
+    {
+        "id": 1835895,
+        "name": "Seosan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.452217,
+            "lat": 36.78167
+        }
+    },
+    {
+        "id": 1835967,
+        "name": "Jenzan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.297501,
+            "lat": 36.240829
+        }
+    },
+    {
+        "id": 1836034,
+        "name": "Seisan-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.066666,
+            "lat": 35.099998
+        }
+    },
+    {
+        "id": 1836164,
+        "name": "Songjeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.357224,
+            "lat": 35.589169
+        }
+    },
+    {
+        "id": 1836208,
+        "name": "Seonghwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.131393,
+            "lat": 36.915562
+        }
+    },
+    {
+        "id": 1836553,
+        "name": "Sokcho",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.59111,
+            "lat": 38.208328
+        }
+    },
+    {
+        "id": 1837055,
+        "name": "Yongsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.966667,
+            "lat": 37.533329
+        }
+    },
+    {
+        "id": 1837217,
+        "name": "Sinch’ŏn-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.083328,
+            "lat": 37.51667
+        }
+    },
+    {
+        "id": 1837640,
+        "name": "Sangok",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.616669,
+            "lat": 34.833328
+        }
+    },
+    {
+        "id": 1837660,
+        "name": "Sang-ni",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.106201,
+            "lat": 36.251099
+        }
+    },
+    {
+        "id": 1837706,
+        "name": "Sangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.160553,
+            "lat": 36.415279
+        }
+    },
+    {
+        "id": 1838069,
+        "name": "Santyoku",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.170837,
+            "lat": 37.440559
+        }
+    },
+    {
+        "id": 1838294,
+        "name": "Shisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.088608,
+            "lat": 35.084171
+        }
+    },
+    {
+        "id": 1838343,
+        "name": "Pyeongtaek",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.08889,
+            "lat": 36.99472
+        }
+    },
+    {
+        "id": 1838431,
+        "name": "Pyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.0
+        }
+    },
+    {
+        "id": 1838508,
+        "name": "Buyeo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.912498,
+            "lat": 36.28194
+        }
+    },
+    {
+        "id": 1838519,
+        "name": "Busan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.050003,
+            "lat": 35.133331
+        }
+    },
+    {
+        "id": 1838524,
+        "name": "Busan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.040283,
+            "lat": 35.102779
+        }
+    },
+    {
+        "id": 1838716,
+        "name": "Bucheon-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.783058,
+            "lat": 37.49889
+        }
+    },
+    {
+        "id": 1838722,
+        "name": "Puan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.731941,
+            "lat": 35.728062
+        }
+    },
+    {
+        "id": 1838740,
+        "name": "Boseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.080887,
+            "lat": 34.769718
+        }
+    },
+    {
+        "id": 1839011,
+        "name": "Beolgyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.342934,
+            "lat": 34.84494
+        }
+    },
+    {
+        "id": 1839071,
+        "name": "Pohang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.365005,
+            "lat": 36.032219
+        }
+    },
+    {
+        "id": 1839652,
+        "name": "Osan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.070557,
+            "lat": 37.152222
+        }
+    },
+    {
+        "id": 1839726,
+        "name": "Asan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.004173,
+            "lat": 36.783611
+        }
+    },
+    {
+        "id": 1839873,
+        "name": "Okcheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.568001,
+            "lat": 36.301201
+        }
+    },
+    {
+        "id": 1840179,
+        "name": "Kosong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.467606,
+            "lat": 38.378811
+        }
+    },
+    {
+        "id": 1840211,
+        "name": "Nonsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.084717,
+            "lat": 36.203892
+        }
+    },
+    {
+        "id": 1840377,
+        "name": "Namyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.816673,
+            "lat": 37.208889
+        }
+    },
+    {
+        "id": 1840379,
+        "name": "Nangen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.385834,
+            "lat": 35.41
+        }
+    },
+    {
+        "id": 1840421,
+        "name": "Namp’o-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.790833,
+            "lat": 35.811939
+        }
+    },
+    {
+        "id": 1840454,
+        "name": "Namhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.89444,
+            "lat": 34.839439
+        }
+    },
+    {
+        "id": 1840536,
+        "name": "Naju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.717499,
+            "lat": 35.028332
+        }
+    },
+    {
+        "id": 1840862,
+        "name": "Munsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.785004,
+            "lat": 37.85944
+        }
+    },
+    {
+        "id": 1840886,
+        "name": "Mungyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.199463,
+            "lat": 36.594582
+        }
+    },
+    {
+        "id": 1840898,
+        "name": "Paju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.775002,
+            "lat": 37.761108
+        }
+    },
+    {
+        "id": 1840942,
+        "name": "Muju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.661392,
+            "lat": 36.007221
+        }
+    },
+    {
+        "id": 1840982,
+        "name": "Muan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.47139,
+            "lat": 34.989719
+        }
+    },
+    {
+        "id": 1841066,
+        "name": "Mokpo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.388611,
+            "lat": 34.79361
+        }
+    },
+    {
+        "id": 1841149,
+        "name": "Miryang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.748886,
+            "lat": 35.493328
+        }
+    },
+    {
+        "id": 1841245,
+        "name": "Masan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.572495,
+            "lat": 35.208061
+        }
+    },
+    {
+        "id": 1841597,
+        "name": "Gyeongsangbuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.75,
+            "lat": 36.333328
+        }
+    },
+    {
+        "id": 1841598,
+        "name": "Gyeongsan-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.737778,
+            "lat": 35.82333
+        }
+    },
+    {
+        "id": 1841603,
+        "name": "Gyeongju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.21167,
+            "lat": 35.842781
+        }
+    },
+    {
+        "id": 1841610,
+        "name": "Gyeonggi-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.25,
+            "lat": 37.599998
+        }
+    },
+    {
+        "id": 1841775,
+        "name": "Kwangyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.589172,
+            "lat": 34.975281
+        }
+    },
+    {
+        "id": 1841808,
+        "name": "Gwangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.916672,
+            "lat": 35.166672
+        }
+    },
+    {
+        "id": 1841810,
+        "name": "Gwangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.257217,
+            "lat": 37.41
+        }
+    },
+    {
+        "id": 1841811,
+        "name": "Gwangju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.915558,
+            "lat": 35.15472
+        }
+    },
+    {
+        "id": 1841909,
+        "name": "Gwacheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.989166,
+            "lat": 37.42889
+        }
+    },
+    {
+        "id": 1841919,
+        "name": "Kuwaegwan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.394608,
+            "lat": 36.015099
+        }
+    },
+    {
+        "id": 1841976,
+        "name": "Kurye",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.464439,
+            "lat": 35.209438
+        }
+    },
+    {
+        "id": 1841988,
+        "name": "Guri-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.139397,
+            "lat": 37.598598
+        }
+    },
+    {
+        "id": 1842016,
+        "name": "Kunwi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.572784,
+            "lat": 36.234718
+        }
+    },
+    {
+        "id": 1842025,
+        "name": "Gunsan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.711388,
+            "lat": 35.978611
+        }
+    },
+    {
+        "id": 1842030,
+        "name": "Gunpo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.946938,
+            "lat": 37.3675
+        }
+    },
+    {
+        "id": 1842153,
+        "name": "Kinzan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.488892,
+            "lat": 36.103062
+        }
+    },
+    {
+        "id": 1842225,
+        "name": "Gumi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.335999,
+            "lat": 36.113602
+        }
+    },
+    {
+        "id": 1842485,
+        "name": "Goyang-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.834999,
+            "lat": 37.656391
+        }
+    },
+    {
+        "id": 1842518,
+        "name": "Goseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.323608,
+            "lat": 34.976311
+        }
+    },
+    {
+        "id": 1842559,
+        "name": "Koryŏng",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.267548,
+            "lat": 35.729389
+        }
+    },
+    {
+        "id": 1842616,
+        "name": "Gongju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.124718,
+            "lat": 36.455559
+        }
+    },
+    {
+        "id": 1842754,
+        "name": "Kyosai",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.588608,
+            "lat": 34.850281
+        }
+    },
+    {
+        "id": 1842781,
+        "name": "Koyo",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.284462,
+            "lat": 34.610081
+        }
+    },
+    {
+        "id": 1842800,
+        "name": "Koesan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.794724,
+            "lat": 36.810829
+        }
+    },
+    {
+        "id": 1842859,
+        "name": "Koch'ang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.699997,
+            "lat": 35.433331
+        }
+    },
+    {
+        "id": 1842936,
+        "name": "Gimpo-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.714172,
+            "lat": 37.623611
+        }
+    },
+    {
+        "id": 1842939,
+        "name": "Kimje",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.888893,
+            "lat": 35.80167
+        }
+    },
+    {
+        "id": 1842943,
+        "name": "Kimhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.881104,
+            "lat": 35.234169
+        }
+    },
+    {
+        "id": 1842944,
+        "name": "Gimcheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.119812,
+            "lat": 36.121761
+        }
+    },
+    {
+        "id": 1842966,
+        "name": "Gijang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.213882,
+            "lat": 35.244171
+        }
+    },
+    {
+        "id": 1843082,
+        "name": "Gapyeong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.51059,
+            "lat": 37.831009
+        }
+    },
+    {
+        "id": 1843125,
+        "name": "Gangwon-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.25,
+            "lat": 37.75
+        }
+    },
+    {
+        "id": 1843137,
+        "name": "Gangneung",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.896103,
+            "lat": 37.755562
+        }
+    },
+    {
+        "id": 1843163,
+        "name": "Ganghwa-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.485558,
+            "lat": 37.747219
+        }
+    },
+    {
+        "id": 1843491,
+        "name": "Iksan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.954437,
+            "lat": 35.94389
+        }
+    },
+    {
+        "id": 1843495,
+        "name": "Ipyang-ni",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.5,
+            "lat": 36.716671
+        }
+    },
+    {
+        "id": 1843502,
+        "name": "Ipseokdong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.649994,
+            "lat": 35.900002
+        }
+    },
+    {
+        "id": 1843542,
+        "name": "Inje",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.173065,
+            "lat": 38.065559
+        }
+    },
+    {
+        "id": 1843561,
+        "name": "Incheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.416107,
+            "lat": 37.450001
+        }
+    },
+    {
+        "id": 1843564,
+        "name": "Incheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.731667,
+            "lat": 37.453609
+        }
+    },
+    {
+        "id": 1843585,
+        "name": "Imsil",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.279442,
+            "lat": 35.61306
+        }
+    },
+    {
+        "id": 1843702,
+        "name": "Icheon-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.442497,
+            "lat": 37.279171
+        }
+    },
+    {
+        "id": 1843841,
+        "name": "Hwasun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.985001,
+            "lat": 35.059441
+        }
+    },
+    {
+        "id": 1843847,
+        "name": "Hwaseong-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.816902,
+            "lat": 37.206821
+        }
+    },
+    {
+        "id": 1843880,
+        "name": "Hwapyeongri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.569901,
+            "lat": 37.24754
+        }
+    },
+    {
+        "id": 1844045,
+        "name": "Hwacheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.706673,
+            "lat": 38.10611
+        }
+    },
+    {
+        "id": 1844088,
+        "name": "Hŭngjŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.416672,
+            "lat": 36.333328
+        }
+    },
+    {
+        "id": 1844106,
+        "name": "Kulgwan-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.553062,
+            "lat": 37.209721
+        }
+    },
+    {
+        "id": 1844174,
+        "name": "Hongseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.665001,
+            "lat": 36.600899
+        }
+    },
+    {
+        "id": 1844191,
+        "name": "Hongch’ŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.885696,
+            "lat": 37.691799
+        }
+    },
+    {
+        "id": 1844192,
+        "name": "Hongch’ŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.23333,
+            "lat": 36.900002
+        }
+    },
+    {
+        "id": 1844308,
+        "name": "Hayang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.820007,
+            "lat": 35.91333
+        }
+    },
+    {
+        "id": 1844533,
+        "name": "Hamyang",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.727661,
+            "lat": 35.519379
+        }
+    },
+    {
+        "id": 1844539,
+        "name": "Hampyeongsaengtaegongwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.51944,
+            "lat": 35.063889
+        }
+    },
+    {
+        "id": 1844751,
+        "name": "Haenam",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.598892,
+            "lat": 34.57111
+        }
+    },
+    {
+        "id": 1844788,
+        "name": "Hadong-eup Samuso",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.749168,
+            "lat": 35.069439
+        }
+    },
+    {
+        "id": 1844954,
+        "name": "Jungpyong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.58194,
+            "lat": 36.784721
+        }
+    },
+    {
+        "id": 1845033,
+        "name": "Chungju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.93222,
+            "lat": 36.970558
+        }
+    },
+    {
+        "id": 1845105,
+        "name": "Chungcheongnam-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 36.5
+        }
+    },
+    {
+        "id": 1845106,
+        "name": "Chungcheongbuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.0,
+            "lat": 36.75
+        }
+    },
+    {
+        "id": 1845136,
+        "name": "Chuncheon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.734169,
+            "lat": 37.874722
+        }
+    },
+    {
+        "id": 1845275,
+        "name": "Chuja-ri",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.213058,
+            "lat": 37.361938
+        }
+    },
+    {
+        "id": 1845457,
+        "name": "Jeonju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.148888,
+            "lat": 35.821941
+        }
+    },
+    {
+        "id": 1845519,
+        "name": "Cheongsong gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.057007,
+            "lat": 36.43351
+        }
+    },
+    {
+        "id": 1845585,
+        "name": "Ch’ŏngnim",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 129.404724,
+            "lat": 35.991669
+        }
+    },
+    {
+        "id": 1845604,
+        "name": "Cheongju-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.489723,
+            "lat": 36.637218
+        }
+    },
+    {
+        "id": 1845759,
+        "name": "Cheonan",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.152199,
+            "lat": 36.806499
+        }
+    },
+    {
+        "id": 1845788,
+        "name": "Jeollanam-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 34.75
+        }
+    },
+    {
+        "id": 1845789,
+        "name": "Jeollabuk-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.25,
+            "lat": 35.75
+        }
+    },
+    {
+        "id": 1846052,
+        "name": "Chinju",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.084717,
+            "lat": 35.19278
+        }
+    },
+    {
+        "id": 1846069,
+        "name": "Chinhae",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.659714,
+            "lat": 35.149441
+        }
+    },
+    {
+        "id": 1846095,
+        "name": "Chinch'ŏn",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.443329,
+            "lat": 36.85667
+        }
+    },
+    {
+        "id": 1846114,
+        "name": "Jinan-gun",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.425278,
+            "lat": 35.791672
+        }
+    },
+    {
+        "id": 1846149,
+        "name": "Shitsukoku",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.551392,
+            "lat": 35.920559
+        }
+    },
+    {
+        "id": 1846265,
+        "name": "Jeju-do",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.5,
+            "lat": 33.416672
+        }
+    },
+    {
+        "id": 1846266,
+        "name": "Jeju City",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.521942,
+            "lat": 33.50972
+        }
+    },
+    {
+        "id": 1846278,
+        "name": "Teisen",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.211945,
+            "lat": 37.136108
+        }
+    },
+    {
+        "id": 1846326,
+        "name": "Changwon",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.681107,
+            "lat": 35.228062
+        }
+    },
+    {
+        "id": 1846355,
+        "name": "Changsu",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.515228,
+            "lat": 35.648418
+        }
+    },
+    {
+        "id": 1846430,
+        "name": "Changp’o",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.435013,
+            "lat": 35.381691
+        }
+    },
+    {
+        "id": 1846589,
+        "name": "Janggol",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.238403,
+            "lat": 36.174702
+        }
+    },
+    {
+        "id": 1846735,
+        "name": "Jamwon-dong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.0,
+            "lat": 37.51667
+        }
+    },
+    {
+        "id": 1846898,
+        "name": "Anyang-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.926941,
+            "lat": 37.392502
+        }
+    },
+    {
+        "id": 1846912,
+        "name": "Anseong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 127.270279,
+            "lat": 37.01083
+        }
+    },
+    {
+        "id": 1846918,
+        "name": "Ansan-si",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.821938,
+            "lat": 37.323608
+        }
+    },
+    {
+        "id": 1846986,
+        "name": "Andong",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 128.725006,
+            "lat": 36.565559
+        }
+    },
+    {
+        "id": 1847050,
+        "name": "Gaigeturi",
+        "state": "",
+        "country": "KR",
+        "coord": {
+            "lon": 126.318329,
+            "lat": 33.464439
+        }
+    },
+    {
+        "id": 4736134,
+        "name": "Texas City",
+        "state": "TX",
+        "country": "US",
+        "coord": {
+            "lon": -94.902702,
+            "lat": 29.383841
+        }
+    },
+    {
+        "id": 5391959,
+        "name": "San Francisco",
+        "state": "CA",
+        "country": "US",
+        "coord": {
+            "lon": -122.419418,
+            "lat": 37.774929
+        }
+    },
+    {
+        "id": 1819729,
+        "name": "Hong Kong",
+        "state": "",
+        "country": "HK",
+        "coord": {
+            "lon": 114.157692,
+            "lat": 22.285521
+        }
+    },
+    {
+        "id": 1850147,
+        "name": "Tokyo",
+        "state": "",
+        "country": "JP",
+        "coord": {
+            "lon": 139.691711,
+            "lat": 35.689499
+        }
+    }
+    ]

--- a/LZForecast/LZForecast/Utils/Managers/FileManager.swift
+++ b/LZForecast/LZForecast/Utils/Managers/FileManager.swift
@@ -1,0 +1,32 @@
+//
+//  FileManager.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+import Foundation
+
+final class FileManager {
+    static let shared = FileManager()
+    private init () { }
+    
+    func fetchFileData<T: Codable>(fileName: String, type: T.Type) -> T? {
+        let url = Bundle.main.url(forResource: fileName, withExtension: "json")
+        
+        guard let url = url else { return nil }
+        
+        do {
+            let fetchedData = try Data(contentsOf: url)
+            
+            let decodedData = try JSONDecoder().decode(T.self, from: fetchedData)
+            
+            return decodedData
+        } catch {
+            print("Data fetch failed")
+            print(error)
+        }
+        
+        return nil
+    }
+}

--- a/LZForecast/LZForecast/Utils/Types/City.swift
+++ b/LZForecast/LZForecast/Utils/Types/City.swift
@@ -1,0 +1,14 @@
+//
+//  City.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+struct City: Codable {
+    let id: Int
+    let name: String
+    let state: String
+    let country: String
+    let coord: Coordinate
+}

--- a/LZForecast/LZForecast/Views/Main/MainView.swift
+++ b/LZForecast/LZForecast/Views/Main/MainView.swift
@@ -34,7 +34,7 @@ final class MainView: BaseView {
         var button = UIButton()
         
         var config = UIButton.Configuration.plain()
-        config.image = UIImage(systemName: "star")
+        config.image = UIImage(systemName: "map")
         
         button.configuration = config
         
@@ -45,7 +45,7 @@ final class MainView: BaseView {
         var button = UIButton()
         
         var config = UIButton.Configuration.plain()
-        config.image = UIImage(systemName: "person")
+        config.image = UIImage(systemName: "list.bullet")
         
         button.configuration = config
         

--- a/LZForecast/LZForecast/Views/Main/MainViewController.swift
+++ b/LZForecast/LZForecast/Views/Main/MainViewController.swift
@@ -44,6 +44,11 @@ final class MainViewController: BaseViewController<MainView> {
     override func bindData() {
         super.bindData()
         
+        viewModel.inputSearchButtonTapped.bind { [weak self] _ in
+            let vc = SearchCityViewController(baseView: SearchCityView())
+            self?.navigationController?.pushViewController(vc, animated: true)
+        }
+        
         viewModel.outPutCityInfo.bind { [weak self] value in
             self?.baseView.cityInfoView.configureData(value)
         }
@@ -69,7 +74,7 @@ final class MainViewController: BaseViewController<MainView> {
     @objc
     
     func bulletListButtonTapped() {
-        print(#function)
+        viewModel.inputSearchButtonTapped.value = ()
     }
     
     override func configureNavigationItem() {

--- a/LZForecast/LZForecast/Views/Main/MainViewController.swift
+++ b/LZForecast/LZForecast/Views/Main/MainViewController.swift
@@ -46,6 +46,9 @@ final class MainViewController: BaseViewController<MainView> {
         
         viewModel.inputSearchButtonTapped.bind { [weak self] _ in
             let vc = SearchCityViewController(baseView: SearchCityView())
+            vc.searchClosure = { id in
+                self?.fetchWeatherData(requestType: .id(id))
+            }
             self?.navigationController?.pushViewController(vc, animated: true)
         }
         
@@ -81,12 +84,12 @@ final class MainViewController: BaseViewController<MainView> {
         super.configureNavigationItem()
     }
     
-    func fetchWeatherData() {
-        WeatherAPIManager.shared.requestWeather(type: .current(.id(1835847)), responseType: WeatherCurrentResponse.self) {[weak self] response in
+    func fetchWeatherData(requestType: RequestDataType = .id(1835847)) {
+        WeatherAPIManager.shared.requestWeather(type: .current(requestType), responseType: WeatherCurrentResponse.self) {[weak self] response in
             self?.viewModel.inputWeatherCurrentResponse.value = response
         }
         
-        WeatherAPIManager.shared.requestWeather(type: .forecast(.id(1835847)), responseType: WeatherForecastResponse.self) { [weak self] response in
+        WeatherAPIManager.shared.requestWeather(type: .forecast(requestType), responseType: WeatherForecastResponse.self) { [weak self] response in
             self?.viewModel.inputWeatherForecastResponse.value = response
         }
     }

--- a/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
+++ b/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
@@ -11,6 +11,7 @@ final class MainViewModel {
     let cellTypes = MainViewCellType.allCases
     var inputWeatherCurrentResponse = Observable(WeatherCurrentResponse(coord: Coordinate(lat: 0, lon: 0), weather: [], main: Main(temp: 0, temp_min: 0, temp_max: 0), wind: Wind(speed: 0, deg: 0, gust: 0), name: ""))
     var inputWeatherForecastResponse = Observable(WeatherForecastResponse(cod: "", message: 0, cnt: 0, list: []))
+    var inputSearchButtonTapped: Observable<Void?> = Observable(())
     
     var outPutCityInfo = Observable(CityInfo(cityName: "", currentTemp: 0.0, forecastStatus: "", maxTemp: 0.0, minTemp: 0.0))
     var outputThreeHourForecast = Observable([ThreeHourForecast]())

--- a/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
+++ b/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
@@ -24,7 +24,6 @@ final class MainViewModel {
         }
         
         inputWeatherForecastResponse.bind { [weak self] _ in
-            print(#function)
             self?.convertForecast()
         }
     }

--- a/LZForecast/LZForecast/Views/SearchCity/SearchCityCell.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/SearchCityCell.swift
@@ -1,0 +1,77 @@
+//
+//  SearchCityCell.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SearchCityCell: BaseTableViewCell {
+    let icon = {
+        let image = UIImageView()
+        image.image = UIImage(systemName: "globe")
+        return image
+    }()
+    let cityName = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 20, weight: .regular)
+        return label
+    }()
+    let country = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        return label
+    }()
+    
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        contentView.addSubview(icon)
+        contentView.addSubview(cityName)
+        contentView.addSubview(country)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        icon.snp.makeConstraints {
+            $0.leading.equalTo(contentView.snp.leading)
+                .offset(8)
+            $0.verticalEdges.equalTo(contentView)
+                .inset(16)
+            $0.width.equalTo(icon.snp.height)
+        }
+        
+        cityName.snp.makeConstraints {
+            $0.leading.equalTo(icon.snp.trailing)
+                .offset(8)
+            $0.top.equalTo(contentView.snp.top)
+                .offset(8)
+        }
+        
+        country.snp.makeConstraints {
+            $0.leading.equalTo(cityName.snp.leading)
+                .offset(8)
+            $0.top.equalTo(cityName.snp.bottom)
+                .offset(8)
+            $0.bottom.equalTo(contentView.snp.bottom)
+                .offset(-8)
+        }
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+        contentView.backgroundColor = .black
+    }
+    
+    func configureData(_ data: City) {
+        cityName.text = data.name
+        country.text = data.country
+    }
+}

--- a/LZForecast/LZForecast/Views/SearchCity/SearchCityView.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/SearchCityView.swift
@@ -1,0 +1,43 @@
+//
+//  SearchCityView.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+import UIKit
+
+import Alamofire
+
+final class SearchCityView: BaseView {
+    let searchBar = UISearchBar()
+    let tableView = UITableView()
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        self.addSubview(searchBar)
+        self.addSubview(tableView)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        searchBar.snp.makeConstraints {
+            $0.top.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom)
+            $0.horizontalEdges.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+        
+        self.backgroundColor = .black
+        searchBar.barStyle = .black
+        tableView.backgroundColor = .black
+    }
+}

--- a/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class SearchCityViewController: BaseViewController<SearchCityView> {
     
     let viewModel = SearchCityViewModel()
+    var searchClosure: ((Int)->Void)?
     
     override func configureDelegate() {
         super.configureDelegate()
@@ -49,5 +50,11 @@ extension SearchCityViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let data = viewModel.cityList[indexPath.row]
+        searchClosure?(data.id)
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
@@ -1,0 +1,53 @@
+//
+//  SearchCityViewController.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+import UIKit
+
+final class SearchCityViewController: BaseViewController<SearchCityView> {
+    
+    let viewModel = SearchCityViewModel()
+    
+    override func configureDelegate() {
+        super.configureDelegate()
+        
+        baseView.searchBar.delegate = self
+        
+        baseView.tableView.delegate = self
+        baseView.tableView.dataSource = self
+        baseView.tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.identifier)
+        baseView.tableView.register(SearchCityCell.self, forCellReuseIdentifier: SearchCityCell.identifier)
+        
+        fetchCityListInfo()
+    }
+    
+    func fetchCityListInfo() {
+        
+    }
+}
+
+extension SearchCityViewController: UISearchBarDelegate {
+    
+}
+
+extension SearchCityViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.cityList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SearchCityCell.identifier, for: indexPath) as? SearchCityCell else {
+            return UITableViewCell()
+        }
+        let data = viewModel.cityList[indexPath.row]
+        cell.configureData(data)
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+}

--- a/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/SearchCityViewController.swift
@@ -22,28 +22,32 @@ final class SearchCityViewController: BaseViewController<SearchCityView> {
         baseView.tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.identifier)
         baseView.tableView.register(SearchCityCell.self, forCellReuseIdentifier: SearchCityCell.identifier)
         
-        fetchCityListInfo()
     }
     
-    func fetchCityListInfo() {
-        
+    
+    override func bindData() {
+        viewModel.filteredCityList.bind { [weak self] _ in
+            self?.baseView.tableView.reloadData()
+        }
     }
 }
 
 extension SearchCityViewController: UISearchBarDelegate {
-    
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        viewModel.inputSearchText.value = searchText
+    }
 }
 
 extension SearchCityViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.cityList.count
+        return viewModel.filteredCityList.value.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SearchCityCell.identifier, for: indexPath) as? SearchCityCell else {
             return UITableViewCell()
         }
-        let data = viewModel.cityList[indexPath.row]
+        let data = viewModel.filteredCityList.value[indexPath.row]
         cell.configureData(data)
         return cell
     }
@@ -53,7 +57,7 @@ extension SearchCityViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let data = viewModel.cityList[indexPath.row]
+        let data = viewModel.filteredCityList.value[indexPath.row]
         searchClosure?(data.id)
         navigationController?.popViewController(animated: true)
     }

--- a/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  SearchCityViewModel.swift
+//  LZForecast
+//
+//  Created by user on 7/15/24.
+//
+
+import Foundation
+
+final class SearchCityViewModel {
+    let cityList: [City] = FileManager.shared.fetchFileData(fileName: "CityList", type: [City].self) ?? []
+}

--- a/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
@@ -9,4 +9,23 @@ import Foundation
 
 final class SearchCityViewModel {
     let cityList: [City] = FileManager.shared.fetchFileData(fileName: "CityList", type: [City].self) ?? []
+    lazy var filteredCityList: Observable<[City]> = Observable(cityList)
+    
+    var inputSearchText = Observable("")
+    
+    init() {
+        inputSearchText.bind { [weak self] value in
+            self?.searchTextChanged(value)
+        }
+    }
+    
+    func searchTextChanged(_ text: String) {
+        if text.isEmpty {
+            filteredCityList.value = cityList
+        } else {
+            filteredCityList.value = cityList.filter {
+                $0.name.localizedStandardContains(text)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🌩️ *Pull requests* 🌤️

🌿 **작업한 브랜치**
https://github.com/alpaka99/LZForecast/tree/%2313/Feat/Implement-CitySearchView

<br></br>

## 🔍 **작업한 결과**
- [x] cityList.json 파일을 app bundle에 넣고, fileManager를 이용하여 데이터들을 불러옵니다
- [x] tableview를 누르면 해당 mainview에서 검색을 할 수 있도록 합니다(Closure를 이용)
- [x]  searchCityView에서 실시간 검색을 구현하여 도시 필터링 가능하게 합니다

<br></br>
## 🔫 **Trouble Shooting**
- FileManager를 이용하여 앱 번들에서 "CityList.json"이라는 이름을 가진 파일을 불러올 수 있도록 하였습니다. 추후에 파일 이름을 받는 부분을 변경하여 더욱 generic한 함수로 만들 수 있을것 같습니다.
- MainView에서 SearchView에 closure를 전달하고, tableView에서 didSelectRowAt을 실행하면 이 closure가 실행되도록 하였습니다. 명세서에 'closure를 이용하여 데이터를 전달하라'고 명시되어있어서 이 방법을 사용하였습니다. 딱히 delegate와 다른게 없다고 생각하여 사용하였습니다.

<br></br>
## 🔊 기타 공유사항


<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|SearchCity 구현|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-15 at 07 02 46](https://github.com/user-attachments/assets/ec371cf1-58c4-45db-af41-a7ad72241565)|

<br></br>

## 📟 관련 이슈
- Resolved:  #13 
