### PR TITLE
[Refactor] Toolbar를 이용해 MainView의 하단 버튼들 구현하기

### DIFF
--- a/LZForecast/LZForecast/App/SceneDelegate.swift
+++ b/LZForecast/LZForecast/App/SceneDelegate.swift
@@ -22,6 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let vc = MainViewController(baseView: MainView())
         let rootNavigationController = UINavigationController(rootViewController: vc)
+        rootNavigationController.isToolbarHidden = false
         
         window?.rootViewController = rootNavigationController
         window?.makeKeyAndVisible()

--- a/LZForecast/LZForecast/Views/Main/MainView.swift
+++ b/LZForecast/LZForecast/Views/Main/MainView.swift
@@ -30,27 +30,27 @@ final class MainView: BaseView {
     
     let scrollView = UIScrollView()
     
-    let mapButton = {
-        var button = UIButton()
-        
-        var config = UIButton.Configuration.plain()
-        config.image = UIImage(systemName: "map")
-        
-        button.configuration = config
-        
-        return button
-    }()
+//    let mapButton = {
+//        var button = UIButton()
+//        
+//        var config = UIButton.Configuration.plain()
+//        config.image = UIImage(systemName: "map")
+//        
+//        button.configuration = config
+//        
+//        return button
+//    }()
 
-    let bulletListButton = {
-        var button = UIButton()
-        
-        var config = UIButton.Configuration.plain()
-        config.image = UIImage(systemName: "list.bullet")
-        
-        button.configuration = config
-        
-        return button
-    }()
+//    let bulletListButton = {
+//        var button = UIButton()
+//        
+//        var config = UIButton.Configuration.plain()
+//        config.image = UIImage(systemName: "list.bullet")
+//        
+//        button.configuration = config
+//        
+//        return button
+//    }()
 
     override func configureHierarchy() {
         super.configureHierarchy()
@@ -65,8 +65,8 @@ final class MainView: BaseView {
         scrollView.addSubview(contentView)
         
         self.addSubview(scrollView)
-        self.addSubview(mapButton)
-        self.addSubview(bulletListButton)
+//        self.addSubview(mapButton)
+//        self.addSubview(bulletListButton)
     }
     
     override func configureLayout() {
@@ -79,10 +79,6 @@ final class MainView: BaseView {
         contentView.snp.makeConstraints {
             $0.verticalEdges.equalTo(scrollView)
             $0.horizontalEdges.equalTo(background)
-        }
-        
-        scrollView.frameLayoutGuide.snp.makeConstraints {
-            $0.edges.equalTo(self)
         }
         
         cityInfoView.snp.makeConstraints {
@@ -115,23 +111,9 @@ final class MainView: BaseView {
         }
         
         scrollView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+            $0.edges.equalTo(self.safeAreaLayoutGuide)
         }
         
-        
-        mapButton.snp.makeConstraints {
-            $0.top.equalTo(scrollView.snp.bottom)
-            $0.leading.equalTo(self)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
-            $0.size.equalTo(50)
-        }
-        
-        bulletListButton.snp.makeConstraints {
-            $0.top.equalTo(scrollView.snp.bottom)
-            $0.trailing.equalTo(self)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
-            $0.size.equalTo(50)
-        }
     }
     
     override func configureUI() {

--- a/LZForecast/LZForecast/Views/Main/MainViewController.swift
+++ b/LZForecast/LZForecast/Views/Main/MainViewController.swift
@@ -16,9 +16,6 @@ final class MainViewController: BaseViewController<MainView> {
     override func configureDelegate() {
         super.configureDelegate()
         
-        baseView.mapButton.addTarget(self, action: #selector(mapButtonTapped), for: .touchUpInside)
-        baseView.bulletListButton.addTarget(self, action: #selector(bulletListButtonTapped), for: .touchUpInside)
-        
         baseView.threeHourForecastView.collectionView.delegate = self
         baseView.threeHourForecastView.collectionView.dataSource = self
         baseView.threeHourForecastView.collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: UICollectionViewCell.identifier)
@@ -35,10 +32,16 @@ final class MainViewController: BaseViewController<MainView> {
         baseView.additionalInfo.collectionView.register(AdditionalInfoCollectionViewCell.self, forCellWithReuseIdentifier: AdditionalInfoCollectionViewCell.identifier)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidLoad() {
+        super.viewDidLoad()
         
         fetchWeatherData()
+        
+        toolbarItems = [
+            UIBarButtonItem(image: UIImage(systemName: "map"), style: .plain, target: self, action: #selector(mapButtonTapped)),
+            UIBarButtonItem(systemItem: .flexibleSpace),
+            UIBarButtonItem(image: UIImage(systemName: "list.bullet"), style: .plain, target: self, action: #selector(bulletListButtonTapped))
+        ]
     }
     
     override func bindData() {
@@ -154,13 +157,4 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
             return cell
         }
     }
-}
-
-
-enum MainViewCellType: CaseIterable {
-    case cityInfo
-    case threeHourForecast
-    case fiveHourForecast
-    case map
-    case additinalInfo
 }


### PR DESCRIPTION
## 🌩️ *Pull requests* 🌤️

🌿 **작업한 브랜치**
https://github.com/alpaka99/LZForecast/tree/%2317/Refactor/Move-buttons-to-Toolbar

<br></br>

## 🔍 **작업한 결과**
- [ ] MainView의 하단 버튼들 toolbar로 이동하기

<br></br>
## 🔫 **Trouble Shooting**
- 기존에 하단에 conatraint로 지정해놓은 버튼들을 toolbar로 옮기고 scrollView를 전체 safeArea만큼의 크기로 잡았습니다. 이로 인해 constraint가 간단해졌으며, 버튼들도 toolbar의 사이즈에 맞게 제대로 들어가는것을 확인했습니다
- toolbarItems에서 화면의 양 끝단에 버튼을 놓기 위해 가운데에 .flexibleSpace인 systemItem을 넣었습니다. SwiftUI의  Spacer()와 같은 역할을 하여 가능한 모든 영역을 차지하는 역할을 합니다. 덕분에 mapButton과 searchListButton이 양 끝단에 적절하게 배치될 수 있었습니다.
```swift
toolbarItems = [
    UIBarButtonItem(mapAttributes), // mapButton
    UIBarButtonItem(systemItem: .flexibleSpace), // Spacer
    UIBarButtonItem(searchListAttributes) // searchListButton
]
```

<br></br>
## 🔊 기타 공유사항
<!-- Any Information To Share -->

<br></br>
<!-- 이미지 자료가 있다면 적어주세요
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "">
||<img src = "">
<br></br>
-->

## 📟 관련 이슈
- Resolved: #17 
