### PR TITLE
[Refactor] API Response ResultType으로 처리하기

### DIFF
--- a/LZForecast/LZForecast/Utils/Managers/FileManager.swift
+++ b/LZForecast/LZForecast/Utils/Managers/FileManager.swift
@@ -11,22 +11,20 @@ final class FileManager {
     static let shared = FileManager()
     private init () { }
     
-    func fetchFileData<T: Codable>(fileName: String, type: T.Type) -> T? {
+    func fetchFileData<T: Codable>(fileName: String, type: T.Type) -> Result<T, Error> {
         let url = Bundle.main.url(forResource: fileName, withExtension: "json")
         
-        guard let url = url else { return nil }
+        guard let url = url else { return .failure(NSError(domain: "URL Creation Error", code: 1)) }
         
         do {
             let fetchedData = try Data(contentsOf: url)
             
             let decodedData = try JSONDecoder().decode(T.self, from: fetchedData)
             
-            return decodedData
+            return .success(decodedData)
         } catch {
             print("Data fetch failed")
-            print(error)
+            return .failure(error)
         }
-        
-        return nil
     }
 }

--- a/LZForecast/LZForecast/Utils/Managers/WeatherAPIManager.swift
+++ b/LZForecast/LZForecast/Utils/Managers/WeatherAPIManager.swift
@@ -14,7 +14,7 @@ final class WeatherAPIManager {
     
     private init() { }
     
-    internal func requestWeather<T: Decodable>(type: URLBuilder, responseType: T.Type, completionHandler: @escaping (T)->Void) {
+    internal func requestWeather<T: Decodable>(type: URLBuilder, responseType: T.Type, completionHandler: @escaping (Result<T, AFError>)->Void) {
         let url = type.url
         let parameters = type.parameters
         
@@ -24,10 +24,9 @@ final class WeatherAPIManager {
         .responseDecodable(of: T.self) { response in
             switch response.result {
             case .success(let value):
-                completionHandler(value)
+                completionHandler(.success(value))
             case .failure(let error):
-                print("Decoding fail")
-                print(error)
+                completionHandler(.failure(error))
             }
         }
     }

--- a/LZForecast/LZForecast/Views/Main/MainViewController.swift
+++ b/LZForecast/LZForecast/Views/Main/MainViewController.swift
@@ -101,12 +101,24 @@ final class MainViewController: BaseViewController<MainView> {
     }
     
     func fetchWeatherData(requestType: RequestDataType = .id(1835847)) {
-        WeatherAPIManager.shared.requestWeather(type: .current(requestType), responseType: WeatherCurrentResponse.self) {[weak self] response in
-            self?.viewModel.inputWeatherCurrentResponse.value = response
+        WeatherAPIManager.shared.requestWeather(type: .current(requestType), responseType: WeatherCurrentResponse.self) {[weak self] result in
+            switch result {
+            case .success(let value):
+                self?.viewModel.inputWeatherCurrentResponse.value = value
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+            
         }
         
-        WeatherAPIManager.shared.requestWeather(type: .forecast(requestType), responseType: WeatherForecastResponse.self) { [weak self] response in
-            self?.viewModel.inputWeatherForecastResponse.value = response
+        WeatherAPIManager.shared.requestWeather(type: .forecast(requestType), responseType: WeatherForecastResponse.self) { [weak self] result in
+            switch result {
+            case .success(let value):
+                self?.viewModel.inputWeatherForecastResponse.value = value
+            case .failure(let error):
+                print(error)
+            }
+            
         }
     }
     

--- a/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
+++ b/LZForecast/LZForecast/Views/Main/ViewModel/MainViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 final class MainViewModel {
-    let cellTypes = MainViewCellType.allCases
     var inputWeatherCurrentResponse = Observable(WeatherCurrentResponse(coord: Coordinate(lat: 0, lon: 0), weather: [], main: Main(temp: 0, temp_min: 0, temp_max: 0), wind: Wind(speed: 0, deg: 0, gust: 0), name: ""))
     var inputWeatherForecastResponse = Observable(WeatherForecastResponse(cod: "", message: 0, cnt: 0, list: []))
     var inputSearchButtonTapped: Observable<Void?> = Observable(())

--- a/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
+++ b/LZForecast/LZForecast/Views/SearchCity/ViewModel/SearchCityViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class SearchCityViewModel {
-    let cityList: [City] = FileManager.shared.fetchFileData(fileName: "CityList", type: [City].self) ?? []
+    private var cityList: [City] = []
     lazy var filteredCityList: Observable<[City]> = Observable(cityList)
     
     var inputSearchText = Observable("")
@@ -16,6 +16,15 @@ final class SearchCityViewModel {
     init() {
         inputSearchText.bind { [weak self] value in
             self?.searchTextChanged(value)
+        }
+        
+        let result = FileManager.shared.fetchFileData(fileName: "CityList", type: [City].self)
+        
+        switch result {
+        case .success(let value):
+            self.cityList = value
+        case .failure(let error):
+            print(error.localizedDescription)
         }
     }
     


### PR DESCRIPTION
## 🌩️ *Pull requests* 🌤️

🌿 **작업한 브랜치**
https://github.com/alpaka99/LZForecast/tree/%2320/Refactor/Use-ResultType-to-Handle-Response

<br></br>

## 🔍 **작업한 결과**
- [x] WeatherAPI Response를 받아와서 처리하는 부분을 ResultType으로 변형

<br></br>
## 🔫 **Trouble Shooting**
- 기존의 Response를 받아와서 처리하는 completionHandler가 단순히 제네릭 타입 T를  반환하는것이 아닌, Result<T, Error> 타입을 반환합니다. 이로 인해서 성공했을때의 처리를 반환값을 받는 곳에서 더 적절하게 처리해줄 수 있다는 생각이 듭니다. 예를 들어 기존의 completionHandler는 제네릭 타입 T?를 반환하여 T를 언래핑해보고, nil이면 error handling을 하고 값이 있다면 기존의 흐름을 이어가는 방법으로 진행하였습니다. ResultType을 이용하면 명시적으로 .success(T), .failure(T)를 이용하여 더 명시적으로 처리를 해줄 수 있을것이라 생각됩니다.
- 또한 한곳에서 여러 error에 대한 핸들링이 가능하다는 점이 유리하게 작용할 수 있다고 생각합니다.

```swift
// 기존의 방식
func callRequest<T>(completionHandler: @escaping (T?)->Void) { ... }

callRequset { response in
    if let response = response {
        // Handle Success
    } else {
        // Handle Failure
    }
}

// ResultType 사용
func callRequest<T>(completionHandler: @escaping (Result<T, Error>)->Void) { ... }

callRequest { response in
    switch response {
        case .success(let response):
            // Handle Success
        case .failure(let error):
            // Handle Failure
    }
}

```
<br></br>
## 🔊 기타 공유사항

<br></br>
<!-- 이미지 자료가 있다면 적어주세요
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "">
||<img src = "">
<br></br>
-->

## 📟 관련 이슈
- Resolved: #20 
